### PR TITLE
ENG-202023 update public api documentation for office visible online attribute

### DIFF
--- a/source/partials/public_api/api_usage/office/index.md.erb
+++ b/source/partials/public_api/api_usage/office/index.md.erb
@@ -183,7 +183,8 @@ Attribute | Type  | Length Limit |
     "company_programs": [
         "Equestrian Equestrian Advisor"
      ],
-    "logo_url": "http://the.office.logo/image.png"
+    "logo_url": "http://the.office.logo/image.png",
+    "office_visible_online": true
   }
   ]
 }
@@ -247,6 +248,7 @@ Attribute | Type |
 |<span class="response-data">deactivated_timestamp</span>|<span class="data-type">Integer or null</span>|
 |<span class="response-data">company_programs</span>|<span class="data-type">Array</span>|
 |<span class="response-data">logo_url</span>|<span class="data-type">String</span>|
+|<span class="response-data">office_visible_online</span>|<span class="data-type">Boolean</span>|
 
 <span class="response-data-head">moxi_works_office_id</span>
 <span class="response-data-remarks">This is the MoxiWorks Platform ID of the office for this <span class='entity-name'>Office</span>. This will be an [RFC 4122](https://tools.ietf.org/html/rfc4122) compliant UUID.</span>
@@ -345,3 +347,6 @@ Attribute | Type |
 
 <span class="response-data-head">logo_url</span>
 <span class="response-data-remarks">URL of the office logo image. This can be null if there is no data for this attribute.</span>
+
+<span class="response-data-head">office_visible_online</span>
+<span class="response-data-remarks">Indicates the "Show Office to Public" value in Roster for this <span class='entity-name'>Office</span>. True corresponds to Yes (visible online); false corresponds to No (not visible online).</span>

--- a/source/partials/public_api/api_usage/office/show.md.erb
+++ b/source/partials/public_api/api_usage/office/show.md.erb
@@ -129,7 +129,8 @@ Attribute | Type  | Length Limit |
     "company_programs": [
         "Equestrian Equestrian Advisor"
       ],
-    "logo_url": "http://the.office.logo/image.png"
+    "logo_url": "http://the.office.logo/image.png",
+    "office_visible_online": true
   }
 
 ```
@@ -180,6 +181,7 @@ Attribute | Type |
 |<span class="response-data">deactivated_timestamp</span>|<span class="data-type">Integer or null</span>|
 |<span class="response-data">company_programs</span>|<span class="data-type">Array</span>|
 |<span class="response-data">logo_url</span>|<span class="data-type">String</span>|
+|<span class="response-data">office_visible_online</span>|<span class="data-type">Boolean</span>|
 
 <span class="response-data-head">moxi_works_office_id</span>
 <span class="response-data-remarks">This is the MoxiWorks Platform ID of the office for this <span class='entity-name'>Office</span>. This will be an [RFC 4122](https://tools.ietf.org/html/rfc4122) compliant UUID.</span>
@@ -277,3 +279,6 @@ Attribute | Type |
 
 <span class="response-data-head">logo_url</span>
 <span class="response-data-remarks">URL of the office logo image. This can be null if there is no data for this attribute.</span>
+
+<span class="response-data-head">office_visible_online</span>
+<span class="response-data-remarks">Indicates the "Show Office to Public" value in Roster for this <span class='entity-name'>Office</span>. True corresponds to Yes (visible online); false corresponds to No (not visible online).</span>


### PR DESCRIPTION
## Description
- Adds `office_visible_online` attribute documentation to the **Office Show** endpoint (`office/show.md.erb`)
- Adds `office_visible_online` attribute documentation to the **Office Index** endpoint (`office/index.md.erb`)
- Each file updated with: response attribute table row (Boolean type), remarks block, and field in success JSON example

## Jira Ticket
 [ENG-202023](https://moxiworks.atlassian.net/browse/ENG-202023)
