### PR TITLE
ENG-205251: Fix presentation_logs index docs to require agent identifier

### DIFF
--- a/source/partials/public_api/api_usage/presentation_log/index.md.erb
+++ b/source/partials/public_api/api_usage/presentation_log/index.md.erb
@@ -124,7 +124,7 @@ Attribute | Type  | Length Limit |
 <span class="required-data">**Required Parameters Are In Red**</span>
 
 <span class="request-data-head"><span class='attribute-name'>moxi_works_agent_id</span> or <span class='attribute-name'>agent_uuid</span> or <span class='attribute-name'>source_agent_id</span></span>
-<span class="request-data-remarks">**One of these parameters may be supplied** Please reference [Agent Identifiers](#agent-identifiers) for information about how to construct your agent identifier request params.</span>
+<span class="request-data-remarks">**One of these parameters must be supplied** Please reference [Agent Identifiers](#agent-identifiers) for information about how to construct your agent identifier request params.</span>
 
 <span class="request-data-head">moxi_works_company_id</span>
 <span class="request-data-remarks">A valid MoxiWorks <span class='entity-name'>Company</span> ID. Use [Company Endpoint](#company) to determine what <span class='attribute-name'>moxi_works_company_id</span> you can use.</span>
@@ -153,8 +153,6 @@ Attribute | Type  | Length Limit |
 
 <span class="request-data-head">include_times</span>
 <span class="request-data-remarks">Pass <em>true</em> for the value of the <span class='attribute-name'>include_times</span> parameter to return delivered and requested times for the presentations included in the response.</span>
-
-<aside class="note">At this time, the attribute <span class='attribute-name'>include_times</span> is only an available query options for agent scoped requests (requests including an agent identifier)</aside>
 
 <span class="request-data-head">type</span>
 <span class="request-data-remarks">When filtering by presentation type, use one of the below attributes `buyer`, `seller`, `buyer_tour`, `annual`.</span>
@@ -290,8 +288,6 @@ Attribute | Type |
 
 <span class="response-data-head">pres_delivered_times</span>
 <span class="response-data-remarks">An array of Unix timestamps representing the times when the presentation slide show has been shared (emailed) by the agent(s). Will be <em>null</em> if <span class='attribute-name'>include_times</span> attribute is not included.</span>
-
-<aside class="note">At this time, the attributes <span class='attribute-name'>pdf_requested_times</span>, <span class='attribute-name'>pdf_delivered_times</span>, <span class='attribute-name'>pres_requested_times</span>, and <span class='attribute-name'>pres_delivered_times</span> will be <em>null</em> if the request query is not scoped to an agent (an agent identifier is not included).</aside>
 
 <span class="response-data-head">external_identifier</span>
 <span class="response-data-remarks">This is the  ID of the <span class='entity-name'>Agent</span> utilized by their company.</span>


### PR DESCRIPTION
  - Corrects the PresentationLog index documentation to reflect that one of moxi_works_agent_id, agent_uuid, or source_agent_id must be supplied (changed from "may be supplied").
  - Removes the redundant include_times agent-scope restriction note — since an agent identifier is now documented as required, all requests are agent-scoped by definition.
  - Removes the redundant response attribute note stating that *_times fields are null when not agent-scoped, for the same reason.
  
Jira ticket - https://moxiworks.atlassian.net/browse/ENG-205251