### PR TITLE
ENG-205920 Update Public API Documentation for client_office_id, alternate_office_ids, and client_agent_id in Listing Endpoints

### DIFF
--- a/source/partials/public_api/api_usage/listing/index.md.erb
+++ b/source/partials/public_api/api_usage/listing/index.md.erb
@@ -417,7 +417,10 @@ Number | Property Type |
   ],
   "BuyerCommissionType": "percent",
   "BuyerCommissionValue": "2.5",
-  "VendorModificationTimestamp": "2018-03-20T11:04:55.659-07:00"
+  "VendorModificationTimestamp": "2018-03-20T11:04:55.659-07:00",
+  "client_office_id": "abc123",
+  "alternate_office_ids": ["def456"],
+  "client_agent_id": "ghi789"
 }
 ]
 }
@@ -500,7 +503,10 @@ Number | Property Type |
   "ListingImages": [],
   "BuyerCommissionType": null,
   "BuyerCommissionValue": null,
-  "VendorModificationTimestamp": null
+  "VendorModificationTimestamp": null,
+  "client_office_id": null,
+  "alternate_office_ids": [],
+  "client_agent_id": null
 }
 ```
 
@@ -612,6 +618,9 @@ Attribute | Type |
 |<span class="response-data">BuyerCommissionType</span>|<span class="response-data"><span class="data-type">String or null</span>
 |<span class="response-data">BuyerCommissionValue</span>|<span class="response-data"><span class="data-type">String or null</span>
 |<span class="response-data">VendorModificationTimestamp</span>|<span class="response-data"><span class="data-type">String or null</span>
+|<span class="response-data">client_office_id</span>|<span class="response-data"><span class="data-type">String or null</span>
+|<span class="response-data">alternate_office_ids</span>|<span class="response-data"><span class="data-type">Array</span>
+|<span class="response-data">client_agent_id</span>|<span class="response-data"><span class="data-type">String or null</span>
 
 <span class="response-data-head">LotSizeAcres</span>
 <span class="response-data-remarks">This is the property size of the listing land in acres. If no data is available for this attribute, it will be `null`.</span>
@@ -862,6 +871,15 @@ Attribute | Type |
 
 <span class="response-data-head">VendorModificationTimestamp</span>
 <span class="response-data-remarks">The date when a listing was last modified by the vendor.</span>
+
+<span class="response-data-head">client_office_id</span>
+<span class="response-data-remarks">The client-specific office identifier associated with this listing.</span>
+
+<span class="response-data-head">alternate_office_ids</span>
+<span class="response-data-remarks">An alternate office identifier associated with this listing.</span>
+
+<span class="response-data-head">client_agent_id</span>
+<span class="response-data-remarks">The client-specific agent identifier associated with this listing.</span>
 
 ###### <span class='attribute-name'>PropertyFeature</span> Objects
 

--- a/source/partials/public_api/api_usage/listing/show.md.erb
+++ b/source/partials/public_api/api_usage/listing/show.md.erb
@@ -249,7 +249,10 @@ Attribute | Type | Length Limit |
   ],
   "BuyerCommissionType": "percent",
   "BuyerCommissionValue": "2.5",
-  "VendorModificationTimestamp": "2018-03-20T11:04:55.659-07:00"
+  "VendorModificationTimestamp": "2018-03-20T11:04:55.659-07:00",
+  "client_office_id": "abc123",
+  "alternate_office_ids": ["def456"],
+  "client_agent_id": "ghi789"
 }
 ```
 
@@ -345,6 +348,9 @@ Attribute | Type |
 |<span class="response-data">BuyerCommissionType</span>|<span class="response-data"><span class="data-type">String or null</span>
 |<span class="response-data">BuyerCommissionValue</span>|<span class="response-data"><span class="data-type">String or null</span>
 |<span class="response-data">VendorModificationTimestamp</span>|<span class="response-data"><span class="data-type">String or null</span>
+|<span class="response-data">client_office_id</span>|<span class="response-data"><span class="data-type">String or null</span>
+|<span class="response-data">alternate_office_ids</span>|<span class="response-data"><span class="data-type">Array</span>
+|<span class="response-data">client_agent_id</span>|<span class="response-data"><span class="data-type">String or null</span>
 
 
 <span class="response-data-head">LotSizeAcres</span>
@@ -593,6 +599,15 @@ Attribute | Type |
 
 <span class="response-data-head">VendorModificationTimestamp</span>
 <span class="response-data-remarks">The date when a listing was last modified by the vendor.</span>
+
+<span class="response-data-head">client_office_id</span>
+<span class="response-data-remarks">The client-specific office identifier associated with this listing.</span>
+
+<span class="response-data-head">alternate_office_ids</span>
+<span class="response-data-remarks">An alternate office identifier associated with this listing.</span>
+
+<span class="response-data-head">client_agent_id</span>
+<span class="response-data-remarks">The client-specific agent identifier associated with this listing.</span>
 
 
 ###### <span class='attribute-name'>PropertyFeature</span> Objects

--- a/source/partials/public_api/api_usage/sold_listing/index.md.erb
+++ b/source/partials/public_api/api_usage/sold_listing/index.md.erb
@@ -369,9 +369,12 @@ Attribute | Type | Length Limit |
   "SoldPrice":192349,
   "BuyerAgentFullName":"Fred Agentguy", 
   "BuyerAgentUUID":"deadbeef-dead-beef-dead-beefdeadbeef", 
-  "BuyerAgentOfficeName":"Super BuyerOffice", 
-  "BuyerAgentOfficeID":"abc123", 
-  "BuyerAgentMoxiWorksOfficeID":"deadbeef-dead-beef-deaddeaddead"
+  "BuyerAgentOfficeName":"Super BuyerOffice",
+  "BuyerAgentOfficeID":"abc123",
+  "BuyerAgentMoxiWorksOfficeID":"deadbeef-dead-beef-deaddeaddead",
+  "client_office_id": "abc123",
+  "alternate_office_ids": ["def456"],
+  "client_agent_id": "ghi789"
 }
 ]
 }
@@ -485,6 +488,9 @@ Attribute | Type |
 |<span class="response-data">BuyerAgentOfficeName</span>|<span class="response-data"><span class="data-type">String</span>
 |<span class="response-data">BuyerAgentOfficeID</span>|<span class="response-data"><span class="data-type">String</span>
 |<span class="response-data">BuyerAgentMoxiWorksOfficeID</span>|<span class="response-data"><span class="data-type">String</span>
+|<span class="response-data">client_office_id</span>|<span class="response-data"><span class="data-type">String or null</span>
+|<span class="response-data">alternate_office_ids</span>|<span class="response-data"><span class="data-type">Array</span>
+|<span class="response-data">client_agent_id</span>|<span class="response-data"><span class="data-type">String or null</span>
 
 <span class="response-data-head">LotSizeAcres</span>
 <span class="response-data-remarks">This is the property size of the listing land in acres. If no data is available for this attribute, it will be `null`.</span>
@@ -736,6 +742,15 @@ Attribute | Type |
 
 <span class="response-data-head">BuyerAgentMoxiWorksOfficeID</span>
 <span class="response-data-remarks">The MoxiWorks ID of the buyer agent's office.</span>
+
+<span class="response-data-head">client_office_id</span>
+<span class="response-data-remarks">The client-specific office identifier associated with this listing.</span>
+
+<span class="response-data-head">alternate_office_ids</span>
+<span class="response-data-remarks">An alternate office identifier associated with this listing.</span>
+
+<span class="response-data-head">client_agent_id</span>
+<span class="response-data-remarks">The client-specific agent identifier associated with this listing.</span>
 
 
 ###### <span class='attribute-name'>CompanyListingAttributes</span> Objects

--- a/source/partials/public_api/api_usage/sold_listing/show.md.erb
+++ b/source/partials/public_api/api_usage/sold_listing/show.md.erb
@@ -239,9 +239,12 @@ Attribute | Type | Length Limit |
   "SoldPrice":192349,
   "BuyerAgentFullName":"Fred Agentguy", 
   "BuyerAgentUUID":"deadbeef-dead-beef-dead-beefdeadbeef", 
-  "BuyerAgentOfficeName":"Super BuyerOffice", 
-  "BuyerAgentOfficeID":"abc123", 
-  "BuyerAgentMoxiWorksOfficeID":"deadbeef-dead-beef-deaddeaddead"
+  "BuyerAgentOfficeName":"Super BuyerOffice",
+  "BuyerAgentOfficeID":"abc123",
+  "BuyerAgentMoxiWorksOfficeID":"deadbeef-dead-beef-deaddeaddead",
+  "client_office_id": "abc123",
+  "alternate_office_ids": ["def456"],
+  "client_agent_id": "ghi789"
 }
 ```
 
@@ -339,6 +342,9 @@ Attribute | Type |
 |<span class="response-data">BuyerAgentOfficeName</span>|<span class="response-data"><span class="data-type">String</span>
 |<span class="response-data">BuyerAgentOfficeID</span>|<span class="response-data"><span class="data-type">String</span>
 |<span class="response-data">BuyerAgentMoxiWorksOfficeID</span>|<span class="response-data"><span class="data-type">String</span>
+|<span class="response-data">client_office_id</span>|<span class="response-data"><span class="data-type">String or null</span>
+|<span class="response-data">alternate_office_ids</span>|<span class="response-data"><span class="data-type">Array</span>
+|<span class="response-data">client_agent_id</span>|<span class="response-data"><span class="data-type">String or null</span>
 
 <span class="response-data-head">LotSizeAcres</span>
 <span class="response-data-remarks">This is the property size of the listing land in acres. If no data is available for this attribute, it will be `null`.</span>
@@ -588,6 +594,15 @@ Attribute | Type |
 
 <span class="response-data-head">BuyerAgentMoxiWorksOfficeID</span>
 <span class="response-data-remarks">The MoxiWorks ID of the buyer agent's office.</span>
+
+<span class="response-data-head">client_office_id</span>
+<span class="response-data-remarks">The client-specific office identifier associated with this listing.</span>
+
+<span class="response-data-head">alternate_office_ids</span>
+<span class="response-data-remarks">An alternate office identifier associated with this listing.</span>
+
+<span class="response-data-head">client_agent_id</span>
+<span class="response-data-remarks">The client-specific agent identifier associated with this listing.</span>
 
 
 ###### <span class='attribute-name'>CompanyListingAttributes</span> Objects


### PR DESCRIPTION
## Summary

Adds documentation for three new fields introduced in ENG-203973 across all four listing endpoint pages:

- `listing.index`
- `listing.show`
- `sold_listing.index`
- `sold_listing.show`

### New fields documented

- **`client_office_id`** (`String or null`) — The client-specific office identifier associated with this listing.
- **`alternate_office_ids`** (`Array`) — An array of alternate office identifiers associated with this listing.
- **`client_agent_id`** (`String or null`) — The client-specific agent identifier associated with this listing.

### Changes per file

Each of the four endpoint files was updated with:
1. New entries in the JSON response example payload
2. New rows in the attribute type table
3. New description entries in the response data section

## Jira

[ENG-205920](https://moxiworks.atlassian.net/browse/ENG-205920)

## Test plan

- [ ] Verify JSON examples are valid and render correctly on the docs site
- [ ] Verify attribute type table rows display correctly
- [ ] Verify description sections render correctly for all three fields across all four endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)